### PR TITLE
chore: update cypress github action to run headed tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,6 +21,4 @@ jobs:
         with:
           headed: true
           browser: ${{ matrix.browser }}
-          env: BROWSER=${{ matrix.browser }}
           record: false
-          command: npm run test:cypress

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.0.2
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
-          config-file: cypress.json
+          headed: true
           browser: ${{ matrix.browser }}
           env: BROWSER=${{ matrix.browser }}
           record: false
-          command: npm run test:cypress -- --headed
+          command: npm run test:cypress


### PR DESCRIPTION
Updates cypress github action to v4 in order to use the fix at
https://github.com/cypress-io/github-action/pull/409