### PR TITLE
feat: use split manifest files

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.4
+      - name: Build manifest
+        run: npm run manifest:${{ matrix.browser }}
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.4
       - name: Build manifest
-        run: npm run manifest:${{ matrix.browser }}
+        run: npm run manifest
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ tests/integration/videos
 
 # Webextension build files
 web-ext-artifacts/
+manifest.json
+manifest-*

--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -1,0 +1,3 @@
+{
+  "manifest_version": 3
+}

--- a/manifests/common.json
+++ b/manifests/common.json
@@ -1,5 +1,4 @@
 {
-  "manifest_version": 2,
   "name": "Tapas RSS Button",
   "version": "1.1.0",
   "description": "A webextension that adds an RSS feed button on tapas.io webcomic pages",
@@ -40,3 +39,4 @@
     }
   }
 }
+

--- a/manifests/common.json
+++ b/manifests/common.json
@@ -32,11 +32,6 @@
   ],
   "options_ui": {
     "page": "src/options/index.html"
-  },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "{395c081e-9f3b-4218-9587-bcbfa467c3b6}"
-    }
   }
 }
 

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -1,0 +1,8 @@
+{
+  "manifest_version": 2,
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{395c081e-9f3b-4218-9587-bcbfa467c3b6}"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "dev": "npm run manifest:firefox && web-ext run -f ${FIREFOX:-firefox}",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "manifest": "npm run manifest:firefox && npm run manifest:chrome",
     "manifest:firefox": "node scripts/merge_manifests.js manifests/common.json manifests/firefox.json && cp manifest.json manifest-firefox.json",
     "manifest:chrome": "node scripts/merge_manifests.js manifests/common.json manifests/chrome.json && cp manifest.json manifest-chrome.json",
     "test": "npm run test:unit && npm run test:cypress",
     "test:unit": "mocha tests/unit/**/*.spec.js",
     "test:cypress": "npm run manifest:firefox && cypress run -b ${BROWSER:-firefox}",
-    "cypress:open": "npm run manifest:firefox && npm run manifest:chrome && cypress open"
+    "cypress:open": "npm run manifest && cypress open"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,18 @@
   "description": "A webextension to add an rss button to tapas.io webcomics pages",
   "main": "",
   "scripts": {
-    "build": "web-ext build -o -i tests/ cypress/ images/ node_modules/ package.json README.md package-lock.json cypress.json",
-    "dev": "web-ext run -f ${FIREFOX:-firefox}",
+    "build": "npm run build:firefox && npm run build:chrome",
+    "build:firefox": "npm run manifest:firefox && web-ext build -a web-ext-artifacts/firefox",
+    "build:chrome": "npm run manifest:chrome && web-ext build -a web-ext-artifacts/chrome",
+    "dev": "npm run manifest:firefox && web-ext run -f ${FIREFOX:-firefox}",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "manifest:firefox": "node scripts/merge_manifests.js manifests/common.json manifests/firefox.json && cp manifest.json manifest-firefox.json",
+    "manifest:chrome": "node scripts/merge_manifests.js manifests/common.json manifests/chrome.json && cp manifest.json manifest-chrome.json",
     "test": "npm run test:unit && npm run test:cypress",
     "test:unit": "mocha tests/unit/**/*.spec.js",
-    "test:cypress": "cypress run -b ${BROWSER:-firefox}",
-    "cypress:open": "cypress open"
+    "test:cypress": "npm run manifest:firefox && cypress run -b ${BROWSER:-firefox}",
+    "cypress:open": "npm run manifest:firefox && npm run manifest:chrome && cypress open"
   },
   "repository": {
     "type": "git",

--- a/scripts/merge_manifests.js
+++ b/scripts/merge_manifests.js
@@ -1,0 +1,15 @@
+const fs = require('fs')
+const { dirname, join } = require('path')
+const { argv } = require('process')
+
+const root = dirname(__dirname)
+const manifest = Object.assign({},
+  ...argv.slice(2)
+    .map(file => fs.readFileSync(join(root, file)))
+    .map(JSON.parse.bind(JSON))
+)
+
+fs.writeFileSync(
+  join(root, 'manifest.json'),
+  JSON.stringify(manifest, null, 2)
+)

--- a/tests/integration/copy.spec.js
+++ b/tests/integration/copy.spec.js
@@ -1,11 +1,12 @@
 const { testPages } = require('../utils/series')
 
 describe('Cypress tests for extension UI changes', () => {
+  const extensionAlias = `tapas-rss-${Cypress.browser.name}`
   beforeEach(async () => {
-    return cy.setExtensionStorage('sync', { rssAction: 'copy' })
+    return cy.setExtensionStorage('sync', { rssAction: 'copy' }, { alias: extensionAlias })
   })
   afterEach(() => {
-    return cy.clearExtensionStorage('sync')
+    return cy.clearExtensionStorage('sync', { alias: extensionAlias })
   })
 
   for (const info of testPages) {

--- a/tests/integration/plugins/index.js
+++ b/tests/integration/plugins/index.js
@@ -19,7 +19,15 @@ const extensionLoader = require('@victal/cypress-extensions-plugin/loader')
 module.exports = (on, config) => {
   on('before:browser:launch', extensionLoader.load({
     source: path.join(__dirname, '..', '..', '..'),
+    alias: 'tapas-rss-firefox',
+    manifest: 'manifest-firefox.json',
     watch: false,
-    validBrowsers: ['chrome', 'firefox']
+    validBrowsers: ['firefox']
+  }, {
+    source: path.join(__dirname, '..', '..', '..'),
+    alias: 'tapas-rss-chrome',
+    manifest: 'manifest-chrome.json',
+    watch: false,
+    validBrowsers: ['chrome']
   }))
 }

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  ignoreFiles: [
+    'web-ext-config.js',
+    'tests/',
+    'cypress/',
+    'images/',
+    'node_modules/',
+    'package.json',
+    'README.md',
+    'package-lock.json',
+    'cypress.json',
+    'manifests/',
+    'scripts',
+    'manifest-chrome.json',
+    'manifest-firefox.json'
+  ],
+  build: {
+    overwriteDest: true
+  }
+}

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -1,8 +1,10 @@
 module.exports = {
   ignoreFiles: [
     'web-ext-config.js',
+    'web-ext-artifacts',
     'tests/',
     'cypress/',
+    'cypress.config.js',
     'images/',
     'node_modules/',
     'package.json',


### PR DESCRIPTION
Use split manifest files for chrome and firefox in order to update the chrome extension to manifest v3 and keep firefox on v2